### PR TITLE
fix(android-voice): throwing method in TelecomHelper

### DIFF
--- a/apps/android-voice/.gitignore
+++ b/apps/android-voice/.gitignore
@@ -7,6 +7,7 @@
 /.idea/workspace.xml
 /.idea/navEditor.xml
 /.idea/assetWizardSettings.xml
+/.idea/deploymentTargetDropDown.xml
 .DS_Store
 /build
 /captures

--- a/apps/android-voice/app/build.gradle
+++ b/apps/android-voice/app/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-messaging-ktx'
 
     // Vonage Client SDK
-    implementation("com.vonage:client-sdk-voice:1.1.0-alpha.7")
+    implementation("com.vonage:client-sdk-voice:1.1.0-alpha.15")
 
     // Retrofit + Moshi (HTTP Client)
     def retrofit_version = "2.9.0"

--- a/apps/android-voice/app/src/main/java/com/example/vonage/voicesampleapp/activities/CallActivity.kt
+++ b/apps/android-voice/app/src/main/java/com/example/vonage/voicesampleapp/activities/CallActivity.kt
@@ -24,7 +24,6 @@ class CallActivity : AppCompatActivity() {
     private val coreContext = App.coreContext
     private val clientManager = coreContext.clientManager
     private val notificationManager = coreContext.notificationManager
-    private val telecomHelper = coreContext.telecomHelper
     private var isMuteToggled = false
 
     /**
@@ -92,7 +91,7 @@ class CallActivity : AppCompatActivity() {
         turnKeyguardOff {
             if(notificationManager.isIncomingCallNotificationActive){
                 notificationManager.dismissIncomingCallNotification(callId)
-                telecomHelper.startIncomingCall(callId, from, type)
+                clientManager.placeIncomingCall(callId, from, type)
             } else {
                 // If the Notification has been canceled in the meantime
                 this.finish()

--- a/apps/android-voice/app/src/main/java/com/example/vonage/voicesampleapp/activities/fragments/DialerFragment.kt
+++ b/apps/android-voice/app/src/main/java/com/example/vonage/voicesampleapp/activities/fragments/DialerFragment.kt
@@ -30,7 +30,7 @@ class DialerFragment : DialogFragment() {
     private var dialedNumber : String get() {
         return binding.dialedNumberTextView.text.toString()
     } set(value) {
-        binding.dialedNumberTextView.text = value
+        binding.dialedNumberTextView.setText(value)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/apps/android-voice/app/src/main/java/com/example/vonage/voicesampleapp/core/VoiceClientManager.kt
+++ b/apps/android-voice/app/src/main/java/com/example/vonage/voicesampleapp/core/VoiceClientManager.kt
@@ -1,7 +1,9 @@
 package com.example.vonage.voicesampleapp.core
 
 import android.content.Context
+import android.net.Uri
 import android.telecom.DisconnectCause
+import android.telecom.TelecomManager
 import com.example.vonage.voicesampleapp.App
 import com.example.vonage.voicesampleapp.push.PushNotificationService
 import com.example.vonage.voicesampleapp.telecom.CallConnection
@@ -14,6 +16,7 @@ import com.vonage.android_core.PushType
 import com.vonage.android_core.VGClientConfig
 import com.vonage.clientcore.core.api.*
 import com.vonage.clientcore.core.api.models.User
+import com.vonage.clientcore.core.conversation.VoiceChannelType
 import com.vonage.voice.api.VoiceClient
 import java.lang.Exception
 
@@ -81,7 +84,7 @@ class VoiceClientManager(private val context: Context) {
             if(isDeviceLocked(context)){
                 coreContext.notificationManager.showIncomingCallNotification(callId, from, type)
             } else {
-                coreContext.telecomHelper.startIncomingCall(callId, from, type)
+                placeIncomingCall(callId, from, type)
             }
         }
 
@@ -103,6 +106,7 @@ class VoiceClientManager(private val context: Context) {
                     HangupReason.remoteHangup -> DisconnectCause.REMOTE to true
                     HangupReason.localHangup -> DisconnectCause.LOCAL to false
                     HangupReason.mediaTimeout -> DisconnectCause.BUSY to true
+                    HangupReason.remoteNoAnswerTimeout -> DisconnectCause.CANCELED to true
                 }
                 disconnect(DisconnectCause(cause))
                 notifyCallDisconnectedToCallActivity(context, isRemote)
@@ -196,7 +200,7 @@ class VoiceClientManager(private val context: Context) {
             } ?: callId?.let {
                 println("Outbound Call successfully started with Call ID: $it")
                 val callee = callContext?.get(Constants.CONTEXT_KEY_CALLEE) ?: Constants.DEFAULT_DIALED_NUMBER
-                coreContext.telecomHelper.startOutgoingCall(it, callee)
+                placeOutgoingCall(it, callee)
             }
         }
     }
@@ -210,7 +214,7 @@ class VoiceClientManager(private val context: Context) {
                     showToast(context, "Call with $callerDisplayName successfully reconnected")
                     coreContext.activeCall ?:
                     // Start a new Outgoing Call if there is not an active one
-                    coreContext.telecomHelper.startOutgoingCall(this.callId, this.callerDisplayName, isReconnected = true)
+                    placeOutgoingCall(this.callId, this.callerDisplayName, isReconnected = true)
                 }
             }
         }
@@ -337,7 +341,64 @@ class VoiceClientManager(private val context: Context) {
         }
     }
 
-    // Utilities to filter active calls
+    /*
+     * Utilities to handle errors on telecomHelper
+     */
+    private fun placeOutgoingCall(callId:CallId, callee: String, isReconnected:Boolean = false){
+        try {
+            coreContext.telecomHelper.startOutgoingCall(callId, callee, isReconnected)
+            // If ConnectionService does not respond within 3 seconds
+            // then mock an outgoing connection
+            TimerManager.startTimer(TimerManager.CONNECTION_SERVICE_TIMER, 3000){
+                mockOutgoingConnection(callId, callee, isReconnected)
+            }
+        } catch (e: Exception){
+            abortOutboundCall(callId, e.message)
+        }
+    }
+
+    fun placeIncomingCall(callId: CallId, caller: String, type: VoiceChannelType){
+        try {
+            coreContext.telecomHelper.startIncomingCall(callId, caller, type)
+        } catch (e: Exception){
+            abortInboundCall(callId, e.message)
+        }
+    }
+
+    private fun abortOutboundCall(callId: CallId, message: String?){
+        showToast(context, "Outgoing Call Error: $message")
+        client.hangup(callId){}
+        notifyCallDisconnectedToCallActivity(context, false)
+    }
+
+    private fun abortInboundCall(callId: CallId, message: String?){
+        showToast(context, "Incoming Call Error: $message")
+        client.reject(callId){}
+        notifyCallDisconnectedToCallActivity(context, false)
+    }
+
+    /**
+     *  ConnectionService not working on some devices (e.g. Samsung)
+     *  is a known issue.
+     *
+     *  This method will mock
+     *  `ConnectionService#onCreateOutgoingConnection`
+     *  and allow outgoing calls without interacting with the Telecom framework.
+     */
+    private fun mockOutgoingConnection(callId: CallId, to: String, isReconnected: Boolean) : CallConnection {
+        showToast(context, "ConnectionService Not Available")
+        val connection = CallConnection(callId).apply {
+            setAddress(Uri.parse(to), TelecomManager.PRESENTATION_ALLOWED)
+            setCallerDisplayName(to, TelecomManager.PRESENTATION_ALLOWED)
+            setDialing()
+            if(isReconnected){ setActive() }
+        }
+        return connection
+    }
+
+    /*
+     * Utilities to filter active calls
+     */
     private fun takeIfActive(callId: CallId) : CallConnection? {
         return coreContext.activeCall?.takeIf { it.callId == callId }
     }

--- a/apps/android-voice/app/src/main/java/com/example/vonage/voicesampleapp/core/VoiceClientManager.kt
+++ b/apps/android-voice/app/src/main/java/com/example/vonage/voicesampleapp/core/VoiceClientManager.kt
@@ -70,7 +70,7 @@ class VoiceClientManager(private val context: Context) {
                     coreContext.activeCall?.run {
                         disconnect(DisconnectCause(DisconnectCause.MISSED))
                         notifyCallDisconnectedToCallActivity(context, false)
-                    }
+                    } ?: navigateToMainActivity(context)
                 }
             )
         }

--- a/apps/android-voice/app/src/main/java/com/example/vonage/voicesampleapp/telecom/CallConnectionService.kt
+++ b/apps/android-voice/app/src/main/java/com/example/vonage/voicesampleapp/telecom/CallConnectionService.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import android.telecom.*
 import android.util.Log
 import com.example.vonage.voicesampleapp.utils.Constants
+import com.example.vonage.voicesampleapp.utils.TimerManager
 import com.example.vonage.voicesampleapp.utils.showToast
 
 /**
@@ -36,6 +37,7 @@ class CallConnectionService : ConnectionService() {
         connectionManagerPhoneAccount: PhoneAccountHandle?,
         request: ConnectionRequest?
     ): Connection {
+        TimerManager.cancelTimer(TimerManager.CONNECTION_SERVICE_TIMER)
         val bundle = request!!.extras
         val callId = bundle.getString(Constants.EXTRA_KEY_CALL_ID)!!
         val to = bundle.getString(Constants.EXTRA_KEY_TO)
@@ -56,6 +58,7 @@ class CallConnectionService : ConnectionService() {
     }
 
     override fun onCreateOutgoingConnectionFailed(connectionManagerPhoneAccount: PhoneAccountHandle?, request: ConnectionRequest?) {
+        TimerManager.cancelTimer(TimerManager.CONNECTION_SERVICE_TIMER)
         Log.e("onCreateOutgoingFailed:",request.toString())
         showToast(applicationContext, "onCreateOutgoingConnectionFailed")
     }

--- a/apps/android-voice/app/src/main/java/com/example/vonage/voicesampleapp/telecom/TelecomHelper.kt
+++ b/apps/android-voice/app/src/main/java/com/example/vonage/voicesampleapp/telecom/TelecomHelper.kt
@@ -90,7 +90,10 @@ class TelecomHelper(private val context: Context) {
         extras.putString(Constants.EXTRA_KEY_CALL_ID, callId)
         extras.putString(Constants.EXTRA_KEY_FROM, from)
         val isManageOwnCallsPermitted = ActivityCompat.checkSelfPermission(context, Manifest.permission.MANAGE_OWN_CALLS) == PackageManager.PERMISSION_GRANTED
-        val isCallPermitted = telecomManager.isIncomingCallPermitted(phoneAccountHandle)
+        val isCallPermitted = try {
+            // This method might throw on some devices (e.g. Xiaomi)
+            telecomManager.isIncomingCallPermitted(phoneAccountHandle)
+        } catch (_ : Exception){ true }
         if (isManageOwnCallsPermitted && isPhoneAccountEnabled && isCallPermitted){
             telecomManager.addNewIncomingCall(phoneAccountHandle, extras)
         }

--- a/apps/android-voice/app/src/main/java/com/example/vonage/voicesampleapp/utils/NavigationUtils.kt
+++ b/apps/android-voice/app/src/main/java/com/example/vonage/voicesampleapp/utils/NavigationUtils.kt
@@ -51,6 +51,15 @@ internal fun CallActivity.showDialerFragment(){
         .commit()
 }
 
+internal fun navigateToMainActivity(context: Context, extras: Bundle? = null){
+    val intent = Intent(context, MainActivity::class.java)
+    extras?.let {
+        intent.putExtras(it)
+    }
+    intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP
+    context.startActivity(intent)
+}
+
 internal fun navigateToCallActivity(context: Context, extras: Bundle? = null){
     val intent = Intent(context, CallActivity::class.java)
     extras?.let {

--- a/apps/android-voice/app/src/main/java/com/example/vonage/voicesampleapp/utils/TimerManager.kt
+++ b/apps/android-voice/app/src/main/java/com/example/vonage/voicesampleapp/utils/TimerManager.kt
@@ -1,0 +1,28 @@
+package com.example.vonage.voicesampleapp.utils
+
+import android.os.Handler
+import android.os.Looper
+
+object TimerManager {
+    private val handler: Handler = Handler(Looper.getMainLooper())
+    private val timerMap: MutableMap<String, Runnable> = mutableMapOf()
+
+    const val CONNECTION_SERVICE_TIMER = "ConnectionServiceTimer"
+
+    fun startTimer(timerId: String, delayMillis: Long, callback: () -> Unit) {
+        val runnable = Runnable {
+            callback.invoke()
+            timerMap.remove(timerId)
+        }
+        timerMap[timerId] = runnable
+        handler.postDelayed(runnable, delayMillis)
+    }
+
+    fun cancelTimer(timerId: String) {
+        val runnable = timerMap[timerId]
+        if (runnable != null) {
+            handler.removeCallbacks(runnable)
+            timerMap.remove(timerId)
+        }
+    }
+}

--- a/apps/android-voice/app/src/main/res/layout/fragment_dialer.xml
+++ b/apps/android-voice/app/src/main/res/layout/fragment_dialer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android">
+<layout xmlns:tools="http://schemas.android.com/tools" xmlns:android="http://schemas.android.com/apk/res/android">
     <LinearLayout android:layout_width="match_parent"
                   android:layout_height="match_parent"
                   android:orientation="vertical">
@@ -22,7 +22,7 @@
                     android:layout_alignParentStart="true"
                     android:layout_centerVertical="true"/>
 
-            <TextView
+            <EditText
                     android:id="@+id/dialed_number_text_view"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
@@ -31,7 +31,10 @@
                     android:layout_toStartOf="@+id/button_backspace"
                     android:layout_toEndOf="@+id/button_dismiss"
                     android:textSize="32sp"
-                    android:layout_centerVertical="true"/>
+                    android:layout_centerVertical="true"
+                    android:autofillHints="phone"
+                    android:inputType="phone"
+                    tools:ignore="LabelFor"/>
 
             <Button
                     android:id="@+id/button_backspace"


### PR DESCRIPTION
As reported by @iujielim, the `TelecomManager#isIncomingCallPermitted` method throws on some specific devices (e.g. Xiaomi). 

Defaulting it to `true` has proven to be a good workaround to keep receiving incoming calls.