### PR TITLE
fix: bug on outbound call

### DIFF
--- a/apps/ios-voice/Podfile
+++ b/apps/ios-voice/Podfile
@@ -6,6 +6,6 @@ target 'VonageSDKClientVOIPExample' do
   use_frameworks!
 
   # Pods for VonageSDKClientVOIPExample
-  pod 'VonageClientSDKVoice', '1.2.0-alpha.12'
+  pod 'VonageClientSDKVoice', '1.2.0-rc.1'
 
 end

--- a/apps/ios-voice/Podfile.lock
+++ b/apps/ios-voice/Podfile.lock
@@ -1,10 +1,10 @@
 PODS:
-  - VonageClientSDKVoice (1.2.0-alpha.12):
-    - VonageWebRTC (~> 99.2.39)
-  - VonageWebRTC (99.2.39)
+  - VonageClientSDKVoice (1.2.0-rc.1):
+    - VonageWebRTC (~> 99.7.23)
+  - VonageWebRTC (99.7.23)
 
 DEPENDENCIES:
-  - VonageClientSDKVoice (= 1.2.0-alpha.12)
+  - VonageClientSDKVoice (= 1.2.0-rc.1)
 
 SPEC REPOS:
   trunk:
@@ -12,9 +12,9 @@ SPEC REPOS:
     - VonageWebRTC
 
 SPEC CHECKSUMS:
-  VonageClientSDKVoice: 324794dc1ac2bbb5b3db6c9418e453f9e4fe41b5
-  VonageWebRTC: 4b57187170ef4ea435006e932600646a0521d6b0
+  VonageClientSDKVoice: e2c0d73375dbb3740467c0a91434e5bc6673a233
+  VonageWebRTC: 63464f74f9e7839f956a1498764778d18d44aad0
 
-PODFILE CHECKSUM: 551f65123ad9e8a8ee3da4855693d11b3be66337
+PODFILE CHECKSUM: 792ba348a786bc8653c7b0da06213ef7e46435ac
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.12.1

--- a/apps/ios-voice/VonageSDKClientVOIPExample/Controllers/Calls/CallController+VGVoiceDelegate.swift
+++ b/apps/ios-voice/VonageSDKClientVOIPExample/Controllers/Calls/CallController+VGVoiceDelegate.swift
@@ -72,11 +72,17 @@ extension VonageCallController: VGVoiceClientDelegate {
     
     // MARK: VGVoiceClientDelegate LegStatus
     
-    func voiceClient(_ client: VGVoiceClient, didReceiveLegStatusUpdateForCall callId: String, withLegId legId: String, andStatus status: VGLegStatus) {
+    func voiceClient(_ client: VGVoiceClient, didReceiveLegStatusUpdateForCall callId: VGCallId, withLegId legId: String, andStatus status: VGLegStatus) {
         if (status == .answered ) {
             let uuid = UUID(uuidString: callId)!
             vonageCallUpdates.send((uuid, CallStatus.answered))
         }
+    }
+    
+    func voiceClient(_ client: VGVoiceClient, didReceiveCallTransferForCall callId: VGCallId, withConversationId conversationId: String) {
+        // this will only be triggered for our own legs
+        let uuid = UUID(uuidString: callId)!
+        vonageCallUpdates.send((uuid, CallStatus.answered)) // report to Call Kit
     }
 
 }

--- a/apps/ios-voice/VonageSDKClientVOIPExample/Controllers/Calls/CallController.swift
+++ b/apps/ios-voice/VonageSDKClientVOIPExample/Controllers/Calls/CallController.swift
@@ -33,6 +33,7 @@ protocol CallController {
     func startOutboundCall(_ context:[String:String]) -> UUID
 }
 
+
 // Private Implementation
 
 class VonageCallController: NSObject {
@@ -58,14 +59,7 @@ class VonageCallController: NSObject {
     private let vonageToken = CurrentValueSubject<String?,Never>(nil)
     
     // Callkit
-    lazy var callProvider = { () -> CXProvider in
-        var config = CXProviderConfiguration()
-        config.supportsVideo = false
-        let provider = CXProvider(configuration: config)
-        provider.setDelegate(self, queue: nil)
-        return provider
-    }()
-    
+    var callProvider: CXProvider!
     lazy var cxController = CXCallController()
     
     // Init
@@ -73,7 +67,7 @@ class VonageCallController: NSObject {
         self.client = client
         super.init()
         client.delegate = self
-        
+        callProvider = initCXProvider()
         bindCallController()
         bindCallkit()
     }
@@ -161,6 +155,14 @@ extension VonageCallController: CallController {
 }
 
 extension VonageCallController {
+    
+    private func initCXProvider()-> CXProvider {
+        var config = CXProviderConfiguration()
+        config.supportsVideo = false
+        let provider = CXProvider(configuration: config)
+        provider.setDelegate(self, queue: nil)
+        return provider
+    }
     
     func bindCallController() {
         vonageToken.dropFirst().filter { $0 == nil }.sink { _ in


### PR DESCRIPTION
Due to lazy init of CXProvider, CXProvider was missing during a sync call
