### PR TITLE
Add iOS Live Activity broadcast channel support

### DIFF
--- a/contact-center/ios-voice/Podfile
+++ b/contact-center/ios-voice/Podfile
@@ -5,6 +5,6 @@ target 'VonageSDKClientVOIPExample' do
   use_frameworks!
 
   # Pods for VonageSDKClientVOIPExample
-  pod 'VonageClientSDKVoice', '2.2.0-alpha.1'
+  pod 'VonageClientSDKVoice', '2.3.0'
 
 end

--- a/contact-center/ios-voice/Podfile.lock
+++ b/contact-center/ios-voice/Podfile.lock
@@ -1,10 +1,10 @@
 PODS:
-  - VonageClientSDKVoice (2.2.0-alpha.1):
+  - VonageClientSDKVoice (2.3.0):
     - VonageWebRTC (~> 121.1.100)
-  - VonageWebRTC (121.1.100)
+  - VonageWebRTC (121.1.102)
 
 DEPENDENCIES:
-  - VonageClientSDKVoice (= 2.2.0-alpha.1)
+  - VonageClientSDKVoice (= 2.3.0)
 
 SPEC REPOS:
   trunk:
@@ -12,9 +12,9 @@ SPEC REPOS:
     - VonageWebRTC
 
 SPEC CHECKSUMS:
-  VonageClientSDKVoice: ee010dfa22d8963e4d432fd2f5573e089a327e9f
-  VonageWebRTC: cc915fbcf91f82c71ad37dc576aca1025ecdb91c
+  VonageClientSDKVoice: 031078ac6b4bda51ee19649ab5d1d7e36383b992
+  VonageWebRTC: 51ba476e367055ee0cf8e0d8b055819437d0453f
 
-PODFILE CHECKSUM: c2982cd7559bccdc4b73719c74aba12d7a931418
+PODFILE CHECKSUM: 43aa92441b61ca82956cf295c4f81dd5c4da0c66
 
 COCOAPODS: 1.16.2

--- a/contact-center/ios-voice/TestWidgetExtension/AppIntent.swift
+++ b/contact-center/ios-voice/TestWidgetExtension/AppIntent.swift
@@ -1,0 +1,18 @@
+//
+//  AppIntent.swift
+//  TestWidgetExtension
+//
+//  Created by Salvatore Di Cara on 13/04/2026.
+//
+
+import WidgetKit
+import AppIntents
+
+struct ConfigurationAppIntent: WidgetConfigurationIntent {
+    static var title: LocalizedStringResource { "Configuration" }
+    static var description: IntentDescription { "This is an example widget." }
+
+    // An example configurable parameter.
+    @Parameter(title: "Favorite Emoji", default: "😃")
+    var favoriteEmoji: String
+}

--- a/contact-center/ios-voice/TestWidgetExtension/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/contact-center/ios-voice/TestWidgetExtension/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/contact-center/ios-voice/TestWidgetExtension/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/contact-center/ios-voice/TestWidgetExtension/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "tinted"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/contact-center/ios-voice/TestWidgetExtension/Assets.xcassets/Contents.json
+++ b/contact-center/ios-voice/TestWidgetExtension/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/contact-center/ios-voice/TestWidgetExtension/Assets.xcassets/WidgetBackground.colorset/Contents.json
+++ b/contact-center/ios-voice/TestWidgetExtension/Assets.xcassets/WidgetBackground.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/contact-center/ios-voice/TestWidgetExtension/Info.plist
+++ b/contact-center/ios-voice/TestWidgetExtension/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/contact-center/ios-voice/TestWidgetExtension/TestWidgetExtension.swift
+++ b/contact-center/ios-voice/TestWidgetExtension/TestWidgetExtension.swift
@@ -1,0 +1,88 @@
+//
+//  TestWidgetExtension.swift
+//  TestWidgetExtension
+//
+//  Created by Salvatore Di Cara on 13/04/2026.
+//
+
+import WidgetKit
+import SwiftUI
+
+struct Provider: AppIntentTimelineProvider {
+    func placeholder(in context: Context) -> SimpleEntry {
+        SimpleEntry(date: Date(), configuration: ConfigurationAppIntent())
+    }
+
+    func snapshot(for configuration: ConfigurationAppIntent, in context: Context) async -> SimpleEntry {
+        SimpleEntry(date: Date(), configuration: configuration)
+    }
+    
+    func timeline(for configuration: ConfigurationAppIntent, in context: Context) async -> Timeline<SimpleEntry> {
+        var entries: [SimpleEntry] = []
+
+        // Generate a timeline consisting of five entries an hour apart, starting from the current date.
+        let currentDate = Date()
+        for hourOffset in 0 ..< 5 {
+            let entryDate = Calendar.current.date(byAdding: .hour, value: hourOffset, to: currentDate)!
+            let entry = SimpleEntry(date: entryDate, configuration: configuration)
+            entries.append(entry)
+        }
+
+        return Timeline(entries: entries, policy: .atEnd)
+    }
+
+//    func relevances() async -> WidgetRelevances<ConfigurationAppIntent> {
+//        // Generate a list containing the contexts this widget is relevant in.
+//    }
+}
+
+struct SimpleEntry: TimelineEntry {
+    let date: Date
+    let configuration: ConfigurationAppIntent
+}
+
+struct TestWidgetExtensionEntryView : View {
+    var entry: Provider.Entry
+
+    var body: some View {
+        VStack {
+            Text("Time:")
+            Text(entry.date, style: .time)
+
+            Text("Favorite Emoji:")
+            Text(entry.configuration.favoriteEmoji)
+        }
+    }
+}
+
+struct TestWidgetExtension: Widget {
+    let kind: String = "TestWidgetExtension"
+
+    var body: some WidgetConfiguration {
+        AppIntentConfiguration(kind: kind, intent: ConfigurationAppIntent.self, provider: Provider()) { entry in
+            TestWidgetExtensionEntryView(entry: entry)
+                .containerBackground(.fill.tertiary, for: .widget)
+        }
+    }
+}
+
+extension ConfigurationAppIntent {
+    fileprivate static var smiley: ConfigurationAppIntent {
+        let intent = ConfigurationAppIntent()
+        intent.favoriteEmoji = "😀"
+        return intent
+    }
+    
+    fileprivate static var starEyes: ConfigurationAppIntent {
+        let intent = ConfigurationAppIntent()
+        intent.favoriteEmoji = "🤩"
+        return intent
+    }
+}
+
+#Preview(as: .systemSmall) {
+    TestWidgetExtension()
+} timeline: {
+    SimpleEntry(date: .now, configuration: .smiley)
+    SimpleEntry(date: .now, configuration: .starEyes)
+}

--- a/contact-center/ios-voice/TestWidgetExtension/TestWidgetExtensionBundle.swift
+++ b/contact-center/ios-voice/TestWidgetExtension/TestWidgetExtensionBundle.swift
@@ -1,0 +1,18 @@
+//
+//  TestWidgetExtensionBundle.swift
+//  TestWidgetExtension
+//
+//  Created by Salvatore Di Cara on 13/04/2026.
+//
+
+import WidgetKit
+import SwiftUI
+
+@main
+struct TestWidgetExtensionBundle: WidgetBundle {
+    var body: some Widget {
+        TestWidgetExtension()
+        TestWidgetExtensionControl()
+        TestWidgetExtensionLiveActivity()
+    }
+}

--- a/contact-center/ios-voice/TestWidgetExtension/TestWidgetExtensionControl.swift
+++ b/contact-center/ios-voice/TestWidgetExtension/TestWidgetExtensionControl.swift
@@ -1,0 +1,77 @@
+//
+//  TestWidgetExtensionControl.swift
+//  TestWidgetExtension
+//
+//  Created by Salvatore Di Cara on 13/04/2026.
+//
+
+import AppIntents
+import SwiftUI
+import WidgetKit
+
+struct TestWidgetExtensionControl: ControlWidget {
+    static let kind: String = "com.vonage.client-sdk.voice-sample.TestWidgetExtension"
+
+    var body: some ControlWidgetConfiguration {
+        AppIntentControlConfiguration(
+            kind: Self.kind,
+            provider: Provider()
+        ) { value in
+            ControlWidgetToggle(
+                "Start Timer",
+                isOn: value.isRunning,
+                action: StartTimerIntent(value.name)
+            ) { isRunning in
+                Label(isRunning ? "On" : "Off", systemImage: "timer")
+            }
+        }
+        .displayName("Timer")
+        .description("A an example control that runs a timer.")
+    }
+}
+
+extension TestWidgetExtensionControl {
+    struct Value {
+        var isRunning: Bool
+        var name: String
+    }
+
+    struct Provider: AppIntentControlValueProvider {
+        func previewValue(configuration: TimerConfiguration) -> Value {
+            TestWidgetExtensionControl.Value(isRunning: false, name: configuration.timerName)
+        }
+
+        func currentValue(configuration: TimerConfiguration) async throws -> Value {
+            let isRunning = true // Check if the timer is running
+            return TestWidgetExtensionControl.Value(isRunning: isRunning, name: configuration.timerName)
+        }
+    }
+}
+
+struct TimerConfiguration: ControlConfigurationIntent {
+    static let title: LocalizedStringResource = "Timer Name Configuration"
+
+    @Parameter(title: "Timer Name", default: "Timer")
+    var timerName: String
+}
+
+struct StartTimerIntent: SetValueIntent {
+    static let title: LocalizedStringResource = "Start a timer"
+
+    @Parameter(title: "Timer Name")
+    var name: String
+
+    @Parameter(title: "Timer is running")
+    var value: Bool
+
+    init() {}
+
+    init(_ name: String) {
+        self.name = name
+    }
+
+    func perform() async throws -> some IntentResult {
+        // Start the timer…
+        return .result()
+    }
+}

--- a/contact-center/ios-voice/TestWidgetExtension/TestWidgetExtensionLiveActivity.swift
+++ b/contact-center/ios-voice/TestWidgetExtension/TestWidgetExtensionLiveActivity.swift
@@ -1,0 +1,81 @@
+//
+//  TestWidgetExtensionLiveActivity.swift
+//  TestWidgetExtension
+//
+//  Created by Salvatore Di Cara on 13/04/2026.
+//
+
+import ActivityKit
+import WidgetKit
+import SwiftUI
+
+struct TestWidgetExtensionLiveActivity: Widget {
+    private func clampedProgress(_ progress: Double) -> Double {
+        min(max(progress, 0.0), 1.0)
+    }
+
+    private func progressLabel(_ progress: Double) -> String {
+        "\(Int((progress * 100).rounded()))%"
+    }
+
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: CallActivityAttributes.self) { context in
+            let progress = clampedProgress(context.state.progress)
+            let progressText = progressLabel(progress)
+
+            // Lock screen/banner UI goes here
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Call \(context.attributes.callId)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Text(progressText)
+                        .font(.title2.monospacedDigit())
+                        .fontWeight(.semibold)
+
+                    Text("complete")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+
+                ProgressView(value: progress, total: 1.0)
+                    .tint(.black)
+            }
+            .padding()
+            .activityBackgroundTint(Color.cyan)
+            .activitySystemActionForegroundColor(Color.black)
+
+        } dynamicIsland: { context in
+            let progress = clampedProgress(context.state.progress)
+            let progressText = progressLabel(progress)
+
+            return DynamicIsland {
+                DynamicIslandExpandedRegion(.center) {
+                    VStack(spacing: 6) {
+                        Text(progressText)
+                            .font(.headline.monospacedDigit())
+
+                        ProgressView(value: progress, total: 1.0)
+                    }
+                    .padding(.horizontal, 8)
+                }
+            } compactLeading: {
+                Text("📞")
+            } compactTrailing: {
+                Text(progressText)
+                    .monospacedDigit()
+            } minimal: {
+                Text(progressText)
+                    .monospacedDigit()
+            }
+        }
+    }
+}
+
+#Preview("Notification", as: .content, using: CallActivityAttributes(callId: "test-123")) {
+   TestWidgetExtensionLiveActivity()
+} contentStates: {
+    CallActivityAttributes.ContentState(progress: 1.0)
+    CallActivityAttributes.ContentState(progress: 0.5)
+}

--- a/contact-center/ios-voice/VonageSDKClientVOIPExample.xcodeproj/project.pbxproj
+++ b/contact-center/ios-voice/VonageSDKClientVOIPExample.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 55;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -12,6 +12,11 @@
 		57F51DEE8D6C4134AEB07C00 /* CoreContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39BFCF9809294A9EBCCAF716 /* CoreContext.swift */; };
 		60DC4418F2FD472C9DD4855F /* VoiceClientManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C5B15A8D0004DAAA2679E65 /* VoiceClientManager.swift */; };
 		D1F2437C2981846E00C49B3F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D1F2437B2981846E00C49B3F /* Assets.xcassets */; };
+		FE3E9C502F8D4799005030D8 /* CallActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE3E9C4F2F8D4799005030D8 /* CallActivityAttributes.swift */; };
+		FE3E9C572F8D47E2005030D8 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FE3E9C562F8D47E2005030D8 /* WidgetKit.framework */; };
+		FE3E9C592F8D47E2005030D8 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FE3E9C582F8D47E2005030D8 /* SwiftUI.framework */; };
+		FE3E9C6A2F8D47E4005030D8 /* TestWidgetExtensionExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = FE3E9C552F8D47E2005030D8 /* TestWidgetExtensionExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		FE3E9C702F8D4899005030D8 /* CallActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE3E9C4F2F8D4799005030D8 /* CallActivityAttributes.swift */; };
 		FE86EACB2ECF76890017C40D /* ErrorNotificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE86EAC92ECF76890017C40D /* ErrorNotificationView.swift */; };
 		FEB9E7712A4CA64C003C2B62 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEB9E7702A4CA64C003C2B62 /* Configuration.swift */; };
 		FED917D32EC3843700F972F4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FED917D02EC3843700F972F4 /* AppDelegate.swift */; };
@@ -36,6 +41,30 @@
 		FEF9D8E52ED9D2DA00C7D2FB /* AudioRoutePickerButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEF9D8E42ED9D2DA00C7D2FB /* AudioRoutePickerButton.swift */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		FE3E9C682F8D47E4005030D8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D1F243672981846C00C49B3F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FE3E9C542F8D47E2005030D8;
+			remoteInfo = TestWidgetExtensionExtension;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		FE3E9C6F2F8D47E4005030D8 /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				FE3E9C6A2F8D47E4005030D8 /* TestWidgetExtensionExtension.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
 		349634D600C084FEBBC0823C /* Pods-VonageSDKClientVOIPExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VonageSDKClientVOIPExample.debug.xcconfig"; path = "Target Support Files/Pods-VonageSDKClientVOIPExample/Pods-VonageSDKClientVOIPExample.debug.xcconfig"; sourceTree = "<group>"; };
 		39BFCF9809294A9EBCCAF716 /* CoreContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreContext.swift; sourceTree = "<group>"; };
@@ -47,6 +76,10 @@
 		D1F2437B2981846E00C49B3F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		D1F243802981846E00C49B3F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D1F2438D298553B800C49B3F /* VonageSDKClientVOIPExample.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = VonageSDKClientVOIPExample.entitlements; sourceTree = "<group>"; };
+		FE3E9C4F2F8D4799005030D8 /* CallActivityAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallActivityAttributes.swift; sourceTree = "<group>"; };
+		FE3E9C552F8D47E2005030D8 /* TestWidgetExtensionExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = TestWidgetExtensionExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		FE3E9C562F8D47E2005030D8 /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
+		FE3E9C582F8D47E2005030D8 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
 		FE86EAC92ECF76890017C40D /* ErrorNotificationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorNotificationView.swift; sourceTree = "<group>"; };
 		FEB9E7702A4CA64C003C2B62 /* Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
 		FEB9E7792A4CB7B4003C2B62 /* secrets.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = secrets.xcconfig; sourceTree = SOURCE_ROOT; };
@@ -72,12 +105,35 @@
 		FEF9D8E42ED9D2DA00C7D2FB /* AudioRoutePickerButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRoutePickerButton.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		FE3E9C6B2F8D47E4005030D8 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = FE3E9C542F8D47E2005030D8 /* TestWidgetExtensionExtension */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		FE3E9C5A2F8D47E2005030D8 /* TestWidgetExtension */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (FE3E9C6B2F8D47E4005030D8 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = TestWidgetExtension; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
+
 /* Begin PBXFrameworksBuildPhase section */
 		D1F2436C2981846C00C49B3F /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				1C3EAD911899A03532712E53 /* Pods_VonageSDKClientVOIPExample.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FE3E9C522F8D47E2005030D8 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FE3E9C592F8D47E2005030D8 /* SwiftUI.framework in Frameworks */,
+				FE3E9C572F8D47E2005030D8 /* WidgetKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -96,6 +152,8 @@
 			isa = PBXGroup;
 			children = (
 				4BABF0FB0703FB934402B443 /* Pods_VonageSDKClientVOIPExample.framework */,
+				FE3E9C562F8D47E2005030D8 /* WidgetKit.framework */,
+				FE3E9C582F8D47E2005030D8 /* SwiftUI.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -115,6 +173,7 @@
 			isa = PBXGroup;
 			children = (
 				D1F243712981846C00C49B3F /* VonageSDKClientVOIPExample */,
+				FE3E9C5A2F8D47E2005030D8 /* TestWidgetExtension */,
 				33D62730B0AAD485C9902E2F /* Frameworks */,
 				F65EA0CE0EC6425A836CC131 /* Pods */,
 				D1F243702981846C00C49B3F /* Products */,
@@ -125,6 +184,7 @@
 			isa = PBXGroup;
 			children = (
 				D1F2436F2981846C00C49B3F /* VonageSDKClientVOIPExample.app */,
+				FE3E9C552F8D47E2005030D8 /* TestWidgetExtensionExtension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -195,6 +255,7 @@
 		FED917D82EC3852F00F972F4 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				FE3E9C4F2F8D4799005030D8 /* CallActivityAttributes.swift */,
 				FED917D72EC3852F00F972F4 /* Call */,
 			);
 			path = Models;
@@ -304,15 +365,39 @@
 				D1F2436D2981846C00C49B3F /* Resources */,
 				2BD9C6713E2E4296CA1EBD82 /* [CP] Embed Pods Frameworks */,
 				D66305CDEE5F5F3B70DA798A /* [CP] Copy Pods Resources */,
+				FE3E9C6F2F8D47E4005030D8 /* Embed Foundation Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				FE3E9C692F8D47E4005030D8 /* PBXTargetDependency */,
 			);
 			name = VonageSDKClientVOIPExample;
 			productName = VonageSDKClientVOIPExample;
 			productReference = D1F2436F2981846C00C49B3F /* VonageSDKClientVOIPExample.app */;
 			productType = "com.apple.product-type.application";
+		};
+		FE3E9C542F8D47E2005030D8 /* TestWidgetExtensionExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FE3E9C6C2F8D47E4005030D8 /* Build configuration list for PBXNativeTarget "TestWidgetExtensionExtension" */;
+			buildPhases = (
+				FE3E9C512F8D47E2005030D8 /* Sources */,
+				FE3E9C522F8D47E2005030D8 /* Frameworks */,
+				FE3E9C532F8D47E2005030D8 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				FE3E9C5A2F8D47E2005030D8 /* TestWidgetExtension */,
+			);
+			name = TestWidgetExtensionExtension;
+			packageProductDependencies = (
+			);
+			productName = TestWidgetExtensionExtension;
+			productReference = FE3E9C552F8D47E2005030D8 /* TestWidgetExtensionExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
 		};
 /* End PBXNativeTarget section */
 
@@ -321,11 +406,14 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1420;
+				LastSwiftUpdateCheck = 2610;
 				LastUpgradeCheck = 1500;
 				TargetAttributes = {
 					D1F2436E2981846C00C49B3F = {
 						CreatedOnToolsVersion = 14.2;
+					};
+					FE3E9C542F8D47E2005030D8 = {
+						CreatedOnToolsVersion = 26.1.1;
 					};
 				};
 			};
@@ -343,6 +431,7 @@
 			projectRoot = "";
 			targets = (
 				D1F2436E2981846C00C49B3F /* VonageSDKClientVOIPExample */,
+				FE3E9C542F8D47E2005030D8 /* TestWidgetExtensionExtension */,
 			);
 		};
 /* End PBXProject section */
@@ -353,6 +442,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				D1F2437C2981846E00C49B3F /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FE3E9C532F8D47E2005030D8 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -367,9 +463,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-VonageSDKClientVOIPExample/Pods-VonageSDKClientVOIPExample-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-VonageSDKClientVOIPExample/Pods-VonageSDKClientVOIPExample-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -406,9 +506,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-VonageSDKClientVOIPExample/Pods-VonageSDKClientVOIPExample-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-VonageSDKClientVOIPExample/Pods-VonageSDKClientVOIPExample-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -423,6 +527,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				FEF9D8E52ED9D2DA00C7D2FB /* AudioRoutePickerButton.swift in Sources */,
+				FE3E9C502F8D4799005030D8 /* CallActivityAttributes.swift in Sources */,
 				57F51DEE8D6C4134AEB07C00 /* CoreContext.swift in Sources */,
 				FED917E72EC3853F00F972F4 /* DialerView.swift in Sources */,
 				FE86EACB2ECF76890017C40D /* ErrorNotificationView.swift in Sources */,
@@ -450,7 +555,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		FE3E9C512F8D47E2005030D8 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FE3E9C702F8D4899005030D8 /* CallActivityAttributes.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		FE3E9C692F8D47E4005030D8 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = FE3E9C542F8D47E2005030D8 /* TestWidgetExtensionExtension */;
+			targetProxy = FE3E9C682F8D47E4005030D8 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		D1F243812981846E00C49B3F /* Debug */ = {
@@ -593,7 +714,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				"INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad[sdk=iphoneos*]" = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				"INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad[sdk=iphonesimulator*]" = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -630,7 +751,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				"INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad[sdk=iphoneos*]" = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				"INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad[sdk=iphonesimulator*]" = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -640,6 +761,77 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.vonage.client-sdk.voice-sample";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		FE3E9C6D2F8D47E4005030D8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 7F2B5ZSP8Q;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = TestWidgetExtension/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = TestWidgetExtension;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 26.1;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.vonage.client-sdk.voice-sample.TestWidgetExtension";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		FE3E9C6E2F8D47E4005030D8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 7F2B5ZSP8Q;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = TestWidgetExtension/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = TestWidgetExtension;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 26.1;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.vonage.client-sdk.voice-sample.TestWidgetExtension";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -662,6 +854,15 @@
 			buildConfigurations = (
 				D1F243842981846E00C49B3F /* Debug */,
 				D1F243852981846E00C49B3F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		FE3E9C6C2F8D47E4005030D8 /* Build configuration list for PBXNativeTarget "TestWidgetExtensionExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FE3E9C6D2F8D47E4005030D8 /* Debug */,
+				FE3E9C6E2F8D47E4005030D8 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/contact-center/ios-voice/VonageSDKClientVOIPExample.xcodeproj/project.pbxproj
+++ b/contact-center/ios-voice/VonageSDKClientVOIPExample.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 70;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -106,7 +106,7 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		FE3E9C6B2F8D47E4005030D8 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+		FE3E9C6B2F8D47E4005030D8 /* Exceptions for "TestWidgetExtension" folder in "TestWidgetExtensionExtension" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
@@ -116,7 +116,18 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		FE3E9C5A2F8D47E2005030D8 /* TestWidgetExtension */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (FE3E9C6B2F8D47E4005030D8 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = TestWidgetExtension; sourceTree = "<group>"; };
+		FE3E9C5A2F8D47E2005030D8 /* TestWidgetExtension */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				FE3E9C6B2F8D47E4005030D8 /* Exceptions for "TestWidgetExtension" folder in "TestWidgetExtensionExtension" target */,
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = TestWidgetExtension;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -393,8 +404,6 @@
 				FE3E9C5A2F8D47E2005030D8 /* TestWidgetExtension */,
 			);
 			name = TestWidgetExtensionExtension;
-			packageProductDependencies = (
-			);
 			productName = TestWidgetExtensionExtension;
 			productReference = FE3E9C552F8D47E2005030D8 /* TestWidgetExtensionExtension.appex */;
 			productType = "com.apple.product-type.app-extension";
@@ -463,13 +472,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-VonageSDKClientVOIPExample/Pods-VonageSDKClientVOIPExample-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-VonageSDKClientVOIPExample/Pods-VonageSDKClientVOIPExample-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -506,13 +511,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-VonageSDKClientVOIPExample/Pods-VonageSDKClientVOIPExample-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-VonageSDKClientVOIPExample/Pods-VonageSDKClientVOIPExample-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/contact-center/ios-voice/VonageSDKClientVOIPExample.xcodeproj/xcshareddata/xcschemes/TestWidgetExtensionExtension.xcscheme
+++ b/contact-center/ios-voice/VonageSDKClientVOIPExample.xcodeproj/xcshareddata/xcschemes/TestWidgetExtensionExtension.xcscheme
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2640"
+   wasCreatedForAppExtension = "YES"
+   version = "2.0">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FE3E9C542F8D47E2005030D8"
+               BuildableName = "TestWidgetExtensionExtension.appex"
+               BlueprintName = "TestWidgetExtensionExtension"
+               ReferencedContainer = "container:VonageSDKClientVOIPExample.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D1F2436E2981846C00C49B3F"
+               BuildableName = "VonageSDKClientVOIPExample.app"
+               BlueprintName = "VonageSDKClientVOIPExample"
+               ReferencedContainer = "container:VonageSDKClientVOIPExample.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      launchStyle = "0"
+      askForAppToLaunch = "Yes"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      launchAutomaticallySubstyle = "2"
+      queueDebuggingEnableBacktraceRecording = "Yes">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D1F2436E2981846C00C49B3F"
+            BuildableName = "VonageSDKClientVOIPExample.app"
+            BlueprintName = "VonageSDKClientVOIPExample"
+            ReferencedContainer = "container:VonageSDKClientVOIPExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "_XCWidgetKind"
+            value = ""
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "_XCWidgetDefaultView"
+            value = "timeline"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "_XCWidgetFamily"
+            value = "systemMedium"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES"
+      askForAppToLaunch = "Yes"
+      launchAutomaticallySubstyle = "2">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D1F2436E2981846C00C49B3F"
+            BuildableName = "VonageSDKClientVOIPExample.app"
+            BlueprintName = "VonageSDKClientVOIPExample"
+            ReferencedContainer = "container:VonageSDKClientVOIPExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/contact-center/ios-voice/VonageSDKClientVOIPExample.xcodeproj/xcshareddata/xcschemes/VonageSDKClientVOIPExample.xcscheme
+++ b/contact-center/ios-voice/VonageSDKClientVOIPExample.xcodeproj/xcshareddata/xcschemes/VonageSDKClientVOIPExample.xcscheme
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2640"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D1F2436E2981846C00C49B3F"
+               BuildableName = "VonageSDKClientVOIPExample.app"
+               BlueprintName = "VonageSDKClientVOIPExample"
+               ReferencedContainer = "container:VonageSDKClientVOIPExample.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      queueDebuggingEnableBacktraceRecording = "Yes">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D1F2436E2981846C00C49B3F"
+            BuildableName = "VonageSDKClientVOIPExample.app"
+            BlueprintName = "VonageSDKClientVOIPExample"
+            ReferencedContainer = "container:VonageSDKClientVOIPExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D1F2436E2981846C00C49B3F"
+            BuildableName = "VonageSDKClientVOIPExample.app"
+            BlueprintName = "VonageSDKClientVOIPExample"
+            ReferencedContainer = "container:VonageSDKClientVOIPExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/contact-center/ios-voice/VonageSDKClientVOIPExample/Core/VoiceClientManager.swift
+++ b/contact-center/ios-voice/VonageSDKClientVOIPExample/Core/VoiceClientManager.swift
@@ -10,6 +10,7 @@ import CallKit
 import PushKit
 import VonageClientSDKVoice
 import AVFoundation
+import ActivityKit
 
 /// Modern VoiceClientManager using Combine for reactive state management
 /// This replaces the old UIKit-based CallController with a clean, SwiftUI-friendly architecture
@@ -41,7 +42,9 @@ class VoiceClientManager: NSObject, ObservableObject {
         
         // Set other config vars here
         // config.rtcStatsTelemetry = false
-        
+        config.apiUrl = "https://api-eu-2.dev.v1.vonagenetworks.net"
+        config.websocketUrl = "wss://api-eu-2.dev.v1.vonagenetworks.net"
+    
         #if targetEnvironment(simulator)
         // On simulator: disable CallKit and enable WebSocket invites
         config.enableWebsocketInvites = true
@@ -113,6 +116,7 @@ class VoiceClientManager: NSObject, ObservableObject {
             }
             
             self.fetchCurrentUser()
+            self.testBroadcastLiveActivity()
             onSuccess?(sessionId)
         }
     }
@@ -268,6 +272,8 @@ class VoiceClientManager: NSObject, ObservableObject {
             return
         }
         
+        print("🤯 VOIP TOKEN: \(voip)")
+        
         // Xcode builds use sandbox APNS; TestFlight/App Store use production
         #if DEBUG
         let isSandbox = true
@@ -300,6 +306,9 @@ class VoiceClientManager: NSObject, ObservableObject {
         
         // Only process Vonage pushes for incoming call invites
         let pushType = VGVoiceClient.vonagePushType(payload.dictionaryPayload)
+        print("PUSH TYPE: \(pushType)")
+        print("PUSH PAYLOAD")
+        print("\(payload.dictionaryPayload)")
         guard pushType == .incomingCall else {
             print("⚠️ Ignoring non-incoming call push type: \(pushType)")
             completion()
@@ -416,6 +425,51 @@ class VoiceClientManager: NSObject, ObservableObject {
     private func setErrorMessage(_ message: String) {
         Task { @MainActor [weak self] in
             self?.errorMessage = message
+        }
+    }
+    
+    // MARK: - Live Activity (Broadcast Push Testing)
+    func testBroadcastLiveActivity() {
+        guard ActivityAuthorizationInfo().areActivitiesEnabled else {
+            print("🔴 Live Activities not enabled")
+            return
+        }
+
+        guard #available(iOS 18.0, *) else {
+            print("🔴 Broadcast Live Activity channels require iOS 18 or later")
+            return
+        }
+
+        let attributes = CallActivityAttributes(callId: "test-\(UUID().uuidString.prefix(8))")
+        let state = CallActivityAttributes.ContentState(progress: 0.0)
+
+        guard let channelId = Configuration.liveActivityChannelId else {
+            print("🔴 Live Activity channel ID missing from secrets configuration")
+            return
+        }
+
+        do {
+            let activity = try Activity.request(
+                attributes: attributes,
+                content: .init(state: state, staleDate: nil),
+                pushType: .channel(channelId)
+            )
+            print("🔴 Live Activity started: \(activity.id)")
+            print("🔴 Live Activity channel: \(channelId)")
+
+            Task {
+                for await content in activity.contentUpdates {
+                    print("🔴 [BROADCAST UPDATE RECEIVED]")
+                    print("🔴 progress: \(content.state.progress)")
+                }
+            }
+            Task {
+                for await activityState in activity.activityStateUpdates {
+                    print("🔴 Activity state changed: \(activityState)")
+                }
+            }
+        } catch {
+            print("🔴 Failed to start Live Activity: \(error)")
         }
     }
     

--- a/contact-center/ios-voice/VonageSDKClientVOIPExample/Info.plist
+++ b/contact-center/ios-voice/VonageSDKClientVOIPExample/Info.plist
@@ -10,12 +10,16 @@
 	<string>$(API_REFRESH_URL)</string>
 	<key>API_KEY</key>
 	<string>$(API_KEY)</string>
+	<key>LIVE_ACTIVITY_CHANNEL_ID</key>
+	<string>$(LIVE_ACTIVITY_CHANNEL_ID)</string>
 	<key>CFBundleIconName</key>
 	<string>AppIcon</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>This app needs access to your microphone to enable voice calls through the Vonage Voice API.</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>NSSupportsLiveActivities</key>
+	<true/>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/contact-center/ios-voice/VonageSDKClientVOIPExample/Models/CallActivityAttributes.swift
+++ b/contact-center/ios-voice/VonageSDKClientVOIPExample/Models/CallActivityAttributes.swift
@@ -1,0 +1,8 @@
+import ActivityKit
+
+struct CallActivityAttributes: ActivityAttributes {
+    struct ContentState: Codable, Hashable {
+        var progress: Double
+    }
+    var callId: String
+}

--- a/contact-center/ios-voice/VonageSDKClientVOIPExample/Utils/Configuration.swift
+++ b/contact-center/ios-voice/VonageSDKClientVOIPExample/Utils/Configuration.swift
@@ -35,4 +35,13 @@ enum Configuration {
     static let apiKey: String = value(for: "API_KEY") ?? ""
     
     static let defaultToken: String = value(for: "VONAGE_API_TOKEN") ?? ""
+
+    static let liveActivityChannelId: String? = {
+        guard let value = value(for: "LIVE_ACTIVITY_CHANNEL_ID"),
+              !value.isEmpty,
+              !value.hasPrefix("$(") else {
+            return nil
+        }
+        return value
+    }()
 }


### PR DESCRIPTION
### Summary

- Add the iOS widget extension and Live Activity model for broadcast push testing 
- Start the Live Activity after login and bind it to the configured broadcast channel 
- Load the channel ID from LIVE_ACTIVITY_CHANNEL_ID secret